### PR TITLE
fix: Opening all files inside .tar.gz

### DIFF
--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -714,14 +714,7 @@ public class ImportingUtilities {
     static public InputStream tryOpenAsArchive(File file, String mimeType, String contentType) throws IOException {
         String fileName = file.getName();
         if (fileName.endsWith(".tar.gz") || fileName.endsWith(".tgz") || isFileGZipped(file)) {
-            TarArchiveInputStream archiveInputStream = new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
-            // TODO: Check whether the below is consuming the first entry (effectively throwing it away)
-            if (archiveInputStream.getNextTarEntry() != null) {
-                // It's a tar archive
-                return archiveInputStream;
-            }
-            // It's not a tar archive, so it must be gzip compressed (or something else)
-            return null;
+            return new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
         } else if (fileName.endsWith(".tar.bz2")) {
             return new TarArchiveInputStream(new BZip2CompressorInputStream(new FileInputStream(file)));
         } else if (fileName.endsWith(".tar") || "application/x-tar".equals(contentType)) {
@@ -784,7 +777,7 @@ public class ImportingUtilities {
             TarArchiveInputStream tis = (TarArchiveInputStream) archiveIS;
             try {
                 TarArchiveEntry te;
-                while (!progress.isCanceled() && (te = tis.getNextTarEntry()) != null) {
+                while (!progress.isCanceled() && (te = tis.getNextEntry()) != null) {
                     if (!te.isDirectory()) {
                         String fileName2 = te.getName();
                         File file2 = allocateFile(rawDataDir, fileName2);


### PR DESCRIPTION
Simplified the opening of tar archives by removing unnecessary check for the
first entry and directly returning the `TarArchiveInputStream` in the `tryOpenAsArchive`
method. Also updated the usage of deprecated `getNextTarEntry` to `getNextEntry` in
ImportingUtilities.java.